### PR TITLE
manpagesの日本語化

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -1,7 +1,4 @@
 ---
 user: USER_NAME
-uid: 1000
-shell: /bin/bash
 password: PASSWORD
 group: GROUP_NAME
-gid: 1000

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -2,14 +2,20 @@
 - name: create group
   group:
     name={{ group }}
-    gid={{ gid }}
   become: yes
 
 - name: create user
   user:
-    name={{ user }}
-    shell={{ shell }}
-    uid={{ uid }}
-    password={{ password }}
-    groups={{ group }}
+    name: "{{ user }}"
+    password: "{{ password | password_hash('sha512') }}"
+    update_password: on_create
   become: yes
+
+- name: man pages ja
+  yum: 
+    name: "{{ packages }}"
+    state: latest
+  vars:
+    packages:
+      - langpacks-ja
+      - man


### PR DESCRIPTION
「個人メモ」
CentOS7までは
man-pages-jaとしていたが
CentsOS8からはman-pages-jaがそもそもないので注意