### PR TITLE
実行ユーザがrootの場合のみログの出力が可能、hostsファイルパスの指定

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,3 +1,5 @@
 [defaults]
 roles_path = ./roles
+inventory = ./inventory/hosts
 host_key_checking = false
+log_path = /var/log/ansible.log


### PR DESCRIPTION
[注意]
ログを出力する/var/log配下に書き込めるユーザが
rootユーザだけしか実行できないため、sudoもしくはsu -する必要がある

[hostsファイルパスの省略]
今まで：
ansible-playbook -i inventory/hosts zabbix.yml -k -u root

修正後：
ansible-playbook zabbix.yml -k -u root